### PR TITLE
Add a make push-new-version command to automate updates

### DIFF
--- a/Formula/fe.rb
+++ b/Formula/fe.rb
@@ -1,5 +1,5 @@
 class Fe < Formula
-  desc "fe programming language, for the ethereum virtual machine"
+  desc "Compiler for the Fe programming language"
   homepage "https://github.com/ethereum/fe"
   version "0.22.0"
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+.PHONY: push-new-version
+push-new-version:
+	echo -e "\033[0;32mPushing a new version...\033[0m"
+
+	./scripts/update.sh > Formula/fe.rb
+
+	git add Formula/fe.rb
+	git commit -m "Update to latest version"
+	git push origin main

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+if [ $# -ne 1 ]; then
+  # If the script is invoked without version parameter, it will figure out the latest release automatically
+  version=$(curl -s -L -o /dev/null -w %{url_effective} https://github.com/ethereum/fe/releases/latest | sed 's/.*tag\/v//')
+else
+  version=$1
+fi
+
+url_linux="https://github.com/ethereum/fe/releases/download/v${version}/fe_amd64"
+url_mac="https://github.com/ethereum/fe/releases/download/v${version}/fe_mac"
+
+sha256_linux=$(curl -Ls "$url_linux" | shasum -a 256 | awk '{print $1}')
+sha256_mac=$(curl -Ls "$url_mac" | shasum -a 256 | awk '{print $1}')
+
+
+blueprint="
+class Fe < Formula
+  desc \"fe programming language, for the ethereum virtual machine\"
+  homepage \"https://github.com/ethereum/fe\"
+  version \"${version}\"
+
+  if OS.mac?
+    url \"https://github.com/ethereum/fe/releases/download/v${version}/fe_mac\"
+    sha256 \"${sha256_mac}\"
+  end
+
+  if OS.linux? && Hardware::CPU.intel?
+    url \"https://github.com/ethereum/fe/releases/download/v${version}/fe_amd64\"
+    sha256 \"${sha256_linux}\"
+  end
+
+  def install
+    if OS.mac?
+      bin.install \"fe_mac\" => \"fe\"
+    else
+      bin.install \"fe_amd64\" => \"fe\"
+    end
+  end
+end
+"
+
+echo "$blueprint"

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -16,7 +16,7 @@ sha256_mac=$(curl -Ls "$url_mac" | shasum -a 256 | awk '{print $1}')
 
 blueprint="
 class Fe < Formula
-  desc \"fe programming language, for the ethereum virtual machine\"
+  desc \"Compiler for the Fe programming language\"
   homepage \"https://github.com/ethereum/fe\"
   version \"${version}\"
 


### PR DESCRIPTION
Hey @sbillig this is a basic start to get the brew updates automated. Basically just need to run `make push-new-version` and it will create and push a new commit to update this repo to the latest fe version. The next step would be to hook this up with our CI from the main repo so that it gets invoked whenever we cut a new release.

I tested it and it works fine.