### PR TITLE
CI job to autodetect releases and make them available via brew 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,8 @@ name: cut new release
 
 on:
   schedule:
-    - cron:  '*/10 * * * *'
+    - cron: '*/15 * * * *'
+
 jobs:
   trigger:
     runs-on: ubuntu-latest
@@ -14,15 +15,12 @@ jobs:
         run: |
           ./scripts/check-for-update.sh
         id: version_check
-        continue-on-error: true  # This allows the workflow to continue even if the script fails
       - name: Run second script if the versions differ
-        if: steps.version_check.outcome == 'failure'
         run: |
           ./scripts/archive-current-formula.sh
           ./scripts/update.sh > Formula/fe.rb
           git config --global user.email "github-actions-bot@example.com"
           git config --global user.name "GitHub Actions Bot"
-          git checkout -b testbranch3
           git add .
           git commit -m "Added new Release via GitHub Actions"
           git push origin main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: cut new release
+
+on:
+  schedule:
+    - cron:  '*/10 * * * *'
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Run first script
+        run: |
+          ./scripts/check-for-update.sh
+        id: version_check
+        continue-on-error: true  # This allows the workflow to continue even if the script fails
+      - name: Run second script if the versions differ
+        if: steps.version_check.outcome == 'failure'
+        run: |
+          ./scripts/archive-current-formula.sh
+          ./scripts/update.sh > Formula/fe.rb
+          git config --global user.email "github-actions-bot@example.com"
+          git config --global user.name "GitHub Actions Bot"
+          git checkout -b testbranch3
+          git add .
+          git commit -m "Added new Release via GitHub Actions"
+          git push origin main

--- a/Formula/fe.rb
+++ b/Formula/fe.rb
@@ -1,7 +1,6 @@
 class Fe < Formula
   desc "Compiler for the Fe programming language"
   homepage "https://github.com/ethereum/fe"
-  version "0.24.0"
 
   if OS.mac?
     url "https://github.com/ethereum/fe/releases/download/v0.24.0/fe_mac"

--- a/scripts/archive-current-formula.sh
+++ b/scripts/archive-current-formula.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Change the working directory to the script's directory
+cd $(dirname "$0") || exit
+
+# Path to the input file
+input_file="../Formula/fe.rb"
+
+# Extract the version from the input file
+version=$(grep -o 'v[0-9]\+\.[0-9]\+\.[0-9]\+' "$input_file" | head -n 1 | sed 's/v//')
+
+# Check if version is not empty
+if [ -n "$version" ]; then
+  # Define the new filename
+  new_filename="../Formula/fe@${version}.rb"
+  
+  # Check if the new filename already exists
+  if [ -e "$new_filename" ]; then
+    echo "File '$new_filename' already exists."
+  else
+    # Rename the file
+    mv "$input_file" "$new_filename"
+    echo "File renamed to '$new_filename'."
+  fi
+else
+  echo "Version not found in the file."
+fi

--- a/scripts/check-for-update.sh
+++ b/scripts/check-for-update.sh
@@ -12,8 +12,8 @@ formula_version=$(./get-formula-version.sh)
 # Compare the versions
 if [ "$latest_version" != "$formula_version" ]; then
   echo "Versions differ: Latest version is $latest_version, Formula version is $formula_version"
-  exit 1
+  exit 0
 else
   echo "Versions are the same: $latest_version"
-  exit 0
+  exit 1
 fi

--- a/scripts/check-for-update.sh
+++ b/scripts/check-for-update.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Change the working directory to the script's directory
+cd $(dirname "$0") || exit
+
+# Run the first script to get the latest FE version
+latest_version=$(./get-latest-fe-version.sh)
+
+# Run the second script to get the formula version
+formula_version=$(./get-formula-version.sh)
+
+# Compare the versions
+if [ "$latest_version" != "$formula_version" ]; then
+  echo "Versions differ: Latest version is $latest_version, Formula version is $formula_version"
+  exit 1
+else
+  echo "Versions are the same: $latest_version"
+  exit 0
+fi

--- a/scripts/check-for-update.sh
+++ b/scripts/check-for-update.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 # Change the working directory to the script's directory
 cd $(dirname "$0") || exit
 

--- a/scripts/get-formula-version.sh
+++ b/scripts/get-formula-version.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Change the working directory to the script's directory
+cd $(dirname "$0") || exit
+
+file_path="../Formula/fe.rb"
+
+# Extract version using grep and awk
+version=$(grep -o 'v[0-9]\+\.[0-9]\+\.[0-9]\+' "$file_path" | head -n 1 | sed 's/v//')
+echo $version

--- a/scripts/get-latest-fe-version.sh
+++ b/scripts/get-latest-fe-version.sh
@@ -1,0 +1,1 @@
+echo $(curl -s -L -o /dev/null -w %{url_effective} https://github.com/ethereum/fe/releases/latest | sed 's/.*tag\/v//')

--- a/scripts/get-latest-fe-version.sh
+++ b/scripts/get-latest-fe-version.sh
@@ -1,1 +1,26 @@
-echo $(curl -s -L -o /dev/null -w %{url_effective} https://github.com/ethereum/fe/releases/latest | sed 's/.*tag\/v//')
+#!/bin/bash
+
+# Change the working directory to the script's directory
+cd $(dirname "$0") || exit
+
+# Define your GitHub repository owner and name
+repo_owner="ethereum"
+repo_name="fe"
+
+# Make the API request and store the response in a variable
+response=$(curl -s "https://api.github.com/repos/$repo_owner/$repo_name/releases/latest")
+
+# Check if the request was successful (HTTP status code 200)
+if [[ $? -eq 0 ]]; then
+  # Extract the "name" field from the JSON response
+  name=$(echo "$response" | jq -r ".name")
+
+  # Remove a leading "v" from the name (if present)
+  name_without_v="${name#v}"
+
+  # Print the modified name
+  echo $name_without_v
+else
+  echo "Failed to fetch latest release."
+  exit 1
+fi

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
 
+# Change the working directory to the script's directory
+cd $(dirname "$0") || exit
+
 if [ $# -ne 1 ]; then
   # If the script is invoked without version parameter, it will figure out the latest release automatically
-  version=$(curl -s -L -o /dev/null -w %{url_effective} https://github.com/ethereum/fe/releases/latest | sed 's/.*tag\/v//')
+  version=$(./get-latest-fe-version.sh)
 else
   version=$1
 fi

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -17,7 +17,6 @@ sha256_mac=$(curl -Ls "$url_mac" | shasum -a 256 | awk '{print $1}')
 blueprint="class Fe < Formula
   desc \"Compiler for the Fe programming language\"
   homepage \"https://github.com/ethereum/fe\"
-  version \"${version}\"
 
   if OS.mac?
     url \"https://github.com/ethereum/fe/releases/download/v${version}/fe_mac\"
@@ -36,6 +35,7 @@ blueprint="class Fe < Formula
       bin.install \"fe_amd64\" => \"fe\"
     end
   end
-end"
+end
+"
 
 echo "$blueprint"


### PR DESCRIPTION
This does:

1. Get rid of the brew audit warning regarding redundant usage of `version` (even though, I think it is wrong and leads to uglier workarounds)

2. Created a CI job that does:
  - Check for new Fe releases every 10 minutes (simplest thing to do, no need for changes in the main Fe repo)
  - Archive old Formulae (e.g. current  `fe.rb` would become `fe@0.22.0.rb` and available via brew `install fe@0.22.0`)
  - Update current Formulae to latest release and automatically create and push the commit for it
  
  